### PR TITLE
extra attacks sim + time worn cloak fix

### DIFF
--- a/js/classes/player.js
+++ b/js/classes/player.js
@@ -135,6 +135,9 @@ class Player {
             else if (testType == 6) {
                 this.base.arp += testItem;
             }
+            else if (testType == 9) {
+                this.testExtraAttack = testItem;
+            }
         }
         else {
             this.testItem = testItem;
@@ -192,11 +195,11 @@ class Player {
             this.spells.sunderarmor.nocrit = false;
         }
 
-        
+
         if (this.items.includes(233490)) {
             this.auras.obsidianstrength = new ObsidianStrength(this);
             this.auras.obsidianhaste = new ObsidianHaste(this);
-        } 
+        }
 
         this.update();
         if (this.oh)
@@ -323,6 +326,7 @@ class Player {
                     else if (item.proc && item.proc.chance) {
                         let proc = {}
                         proc.chance = item.proc.chance * 100;
+                        if (item.proc.extra) proc.extra = item.proc.extra;
                         if (item.proc.dmg) proc.magicdmg = item.proc.dmg;
                         if (item.proc.spell) {
                             this.auras[item.proc.spell.toLowerCase()] = eval('new ' + item.proc.spell + '(this)');
@@ -357,10 +361,10 @@ class Player {
                         this.base['moddmgdone'] += 2;
                     if (item.id == 234147)
                         this.base['moddmgdone'] += 4;
-                    
-                    
-                    
-                    
+
+
+
+
                     if (item.id == 228122)
                         this.spells.themoltencore = new TheMoltenCore(this);
 
@@ -408,7 +412,7 @@ class Player {
                     for (let prop in this.base) {
                         if (prop == 'haste' )  { //all haste enchants give castspeed. No need to add the stat to enchants (counter weight is tempench)
                             this.base.haste *= (1 + item.haste / 100) || 1;
-                            this.base.castspeed *= (1 + item.haste / 100) || 1;    
+                            this.base.castspeed *= (1 + item.haste / 100) || 1;
                         } else {
                             if (typeof item[prop] === 'object') {
                                 for (let subprop in item[prop]) {
@@ -949,7 +953,7 @@ class Player {
             this.stats.haste *= (1 + this.auras.flurry.mult_stats.haste / 100);
             this.stats.castspeed /= (1 - this.auras.flurry.mult_stats.haste / 100); //1.18 flurry bug for slam
             //this.stats.castspeed *= (1 + this.auras.flurry.mult_stats.haste / 100); //correct flurry
-        }    
+        }
         if (this.auras.quicknesspotion && this.auras.quicknesspotion.timer){
             this.stats.haste *= (1 + this.auras.quicknesspotion.mult_stats.haste / 100);
             this.stats.castspeed *= (1 + this.auras.quicknesspotion.mult_stats.haste / 100);
@@ -1086,7 +1090,7 @@ class Player {
         if (this.bleedbonus && this.auras.rend && this.auras.rend.timer && this.auras.deepwounds && this.auras.deepwounds.timer) {
             this.stats.dmgmod *= 1.1;
         }
-            
+
     }
     getGlanceReduction(weapon) {
         let diff, high, low;
@@ -1142,7 +1146,7 @@ class Player {
         return Math.max(crit, 0);
     }
     getEffectiveCrit(weapon) {
-   	    return Math.max(0, (this.crit + weapon.crit) + ((this.stats['skill_' + weapon.type] - this.target.defense) * 0.04) + (this.basestance === 'zerk' ? 3 : 0));         
+        return Math.max(0, (this.crit + weapon.crit) + ((this.stats['skill_' + weapon.type] - this.target.defense) * 0.04) + (this.basestance === 'zerk' ? 3 : 0));
     }
     getDodgeChance(weapon) {
         return Math.max(5 - this.stats.expertise - this.target.dodge + (this.target.defense - this.stats['skill_' + weapon.type]) * 0.1, 0);
@@ -1192,7 +1196,7 @@ class Player {
         if (this.auras.consumedrage && oldRage < 60 && this.rage >= 60)
             this.auras.consumedrage.use();
     }
-      // Using this as the best estimate for Turtle Rage gen -> https://www.desmos.com/calculator/aglbbabrg2
+    // Using this as the best estimate for Turtle Rage gen -> https://www.desmos.com/calculator/aglbbabrg2
     // Update these formulas if a better estimate is found
     addRagemh(dmg, result, weapon, spell) {
         let oldRage = this.rage;
@@ -1691,7 +1695,7 @@ class Player {
     dealdamage(dmg, result, weapon, spell, adjacent) {
         if (result != RESULT.MISS && result != RESULT.DODGE) {
             if(spell == null || spell.school == SCHOOL.PHYSICAL)
-              dmg *= (1 - this.armorReduction);
+                dmg *= (1 - this.armorReduction);
             if (!adjacent) this.addRage(dmg, result, weapon, spell);
             return dmg;
         }
@@ -1826,19 +1830,29 @@ class Player {
                     /* start-log */ if (this.logging) this.log(`Trinket 2 proc`); /* end-log */
                 }
             }
-            if (this.attackproc1 && rng10k() < this.attackproc1.chance) {
+            if (this.attackproc1 && !this.attackproc1.extra && rng10k() < this.attackproc1.chance) {
                 if (this.attackproc1.magicdmg) {
                     procdmg += this.attackproc1.chance == 10000 ? this.attackproc1.magicdmg : this.magicproc(this.attackproc1);
                     /* start-log */ if (this.logging) this.log(`Attack proc for ${procdmg}`); /* end-log */
                 }
                 if (this.attackproc1.spell) this.attackproc1.spell.use();
             }
-            if (this.attackproc2 && rng10k() < this.attackproc2.chance) {
+            if (this.attackproc1 && this.attackproc1.extra && !damageSoFar && rng10k() < this.attackproc1.chance) {
+                if (spell) this.batchedextras += this.attackproc1.extra;
+                else batchedextras = this.attackproc1.extra;
+                /* start-log */ if (this.logging) this.log(`Attack proc extra attack`); /* end-log */
+            }
+            if (this.attackproc2 && !this.attackproc2.extra && rng10k() < this.attackproc2.chance) {
                 if (this.attackproc2.magicdmg) {
                     procdmg += this.attackproc2.chance == 10000 ? this.attackproc2.magicdmg : this.magicproc(this.attackproc2);
                     /* start-log */ if (this.logging) this.log(`Attack proc for ${procdmg}`); /* end-log */
                 }
                 if (this.attackproc2.spell) this.attackproc2.spell.use();
+            }
+            if (this.attackproc2 && this.attackproc2.extra && !damageSoFar && rng10k() < this.attackproc2.chance) {
+                if (spell) this.batchedextras += this.attackproc2.extra;
+                else batchedextras = this.attackproc2.extra;
+                /* start-log */ if (this.logging) this.log(`Attack proc extra attack`); /* end-log */
             }
             // Sword spec shouldnt be able to proc itself
             if (this.talents.swordproc && weapon.type == WEAPONTYPE.SWORD && !damageSoFar && this.swordspecstep != step && rng10k() < this.talents.swordproc * 100) {
@@ -1867,6 +1881,12 @@ class Player {
                 if (spell) this.extraattacks++;
                 else extras++;
                 /* start-log */ if (this.logging) this.log(`Timeworn proc`); /* end-log */
+            }
+
+            if (this.testExtraAttack && !damageSoFar && rng10k() < (this.testExtraAttack * 100)) {
+                if (spell) this.batchedextras += 1;
+                else batchedextras = 1;
+                /* start-log */ if (this.logging) this.log(`Stat weight extra attack proc`); /* end-log */
             }
             // Obsidian Champion
             if (weapon.id == 233490 && rng10k() < weapon.proc1.chance && !(this.timer && this.timer < 1500)) {
@@ -1934,7 +1954,7 @@ class Player {
             this.auras.flurry.proc();
         if (!spell && this.mh.windfury && this.mh.windfury.stacks)
             this.mh.windfury.proc();
-        if (this.extraattacks > 0 && this.auras.unrelentingstrikes && !this.auras.unrelentingstrikes.timer) { 
+        if (this.extraattacks > 0 && this.auras.unrelentingstrikes && !this.auras.unrelentingstrikes.timer) {
             this.auras.unrelentingstrikes.use();
         }
         return procdmg;

--- a/js/classes/player.js
+++ b/js/classes/player.js
@@ -793,6 +793,10 @@ class Player {
         }
         if (this.trinketproc1 && this.trinketproc1.usestep) this.trinketproc1.usestep = 0;
         if (this.trinketproc2 && this.trinketproc2.usestep) this.trinketproc2.usestep = 0;
+        this.swordspecstep = 0;
+        this.wailingextrastep = 0;
+        this.hakkariextrastep = 0;
+        this.timewornstep = 0;
         if (this.auras.deepwounds) {
             this.auras.deepwounds.idmg = 0;
         }

--- a/js/ui.js
+++ b/js/ui.js
@@ -253,7 +253,7 @@ SIM.UI = {
                 view.loadWeapons(current_open_page);
             else if (current_open_page == "custom")
                 view.loadCustom();
-            else 
+            else
                 view.loadGear(current_open_page);
         });
 
@@ -435,6 +435,7 @@ SIM.UI = {
             updateStat("arp", await simulateWeight(6, 100));
             updateStat("mhskill", await simulateWeight(7, 1));
             updateStat("ohskill", await simulateWeight(8, 1));
+            updateStat("exattack", await simulateWeight(9, 1));
         }
 
         simulateAll().then(
@@ -716,15 +717,15 @@ SIM.UI = {
                         if (spell.id == runes[type][i].enable)
                             spell.active = false;
                     for (let buff of buffs) {
-                        if (buff.id == runes[type][i].enable) 
+                        if (buff.id == runes[type][i].enable)
                             buff.active = false;
-                        if (buff.id == 2458 && runes[type][i].gladstance) 
+                        if (buff.id == 2458 && runes[type][i].gladstance)
                             buff.active = true;
                     }
-                        
+
                 }
             }
-               
+
         }
         var settings_parent = this.body.find('article.runes');
         var rune_lookup = $(`tr[name="${type}"]`);
@@ -908,7 +909,7 @@ SIM.UI = {
         obj.filter_epic = view.main.find('#filter_epic').hasClass('active');
         obj.bleedreduction = view.fight.find('select[name="bleedreduction"]').val();
         obj.spellqueueing = view.fight.find('select[name="spellqueueing"]').val();
-        
+
 
         let _buffs = [], _rotation = [], _talents = [], _sources = [], _phases = [], _gear = {}, _enchant = {}, _runes = {}, _resistance = {};
         view.buffs.find('.active').each(function () { _buffs.push($(this).attr('data-id')); });
@@ -1003,7 +1004,7 @@ SIM.UI = {
 
         if (storage.targetbasearmor === 3731 || storage.targetbasearmor === null)
             storage.targetbasearmor = 3128;
-        
+
         for (let prop in storage) {
             view.fight.find('input[name="' + prop + '"]').val(storage[prop]);
             view.fight.find('select[name="' + prop + '"]').val(storage[prop]);
@@ -1105,18 +1106,18 @@ SIM.UI = {
 
             if (!item.selected &&
                 ((globalThis.filter_tiger === false && item.name.toLowerCase().indexOf('of the tiger') > -1) ||
-                (globalThis.filter_strength === false && item.name.toLowerCase().indexOf('of strength') > -1) ||
-                (globalThis.filter_bear === false && item.name.toLowerCase().indexOf('of the bear') > -1) ||
-                (globalThis.filter_green === false && item.q == "2") ||
-                (globalThis.filter_blue === false && item.q == "3") ||
-                (globalThis.filter_epic === false && item.q == "4") ||
-                (globalThis.filter_timeworn === false && item.tw))) {
-                    if (globalThis.filter_timeworn === true && item.tw) {
-                        // show item
-                    }
-                    else {
-                        continue;
-                    }
+                    (globalThis.filter_strength === false && item.name.toLowerCase().indexOf('of strength') > -1) ||
+                    (globalThis.filter_bear === false && item.name.toLowerCase().indexOf('of the bear') > -1) ||
+                    (globalThis.filter_green === false && item.q == "2") ||
+                    (globalThis.filter_blue === false && item.q == "3") ||
+                    (globalThis.filter_epic === false && item.q == "4") ||
+                    (globalThis.filter_timeworn === false && item.tw))) {
+                if (globalThis.filter_timeworn === true && item.tw) {
+                    // show item
+                }
+                else {
+                    continue;
+                }
             }
 
             if (filter) {
@@ -1280,25 +1281,25 @@ SIM.UI = {
                     <tbody>`;
 
         for (let item of gear[type]) {
-            
+
             if (!item.selected && (item.r > level || (mode == "sod" && item.q < 3 && item.i < (level - 7)) || (mode == "sod" && item.q == 3 && item.i < (level - 10)) || (mode == "sod" && item.q == 4 && item.i < (level - 15)))) {
                 continue;
             }
 
             if (!item.selected &&
                 ((globalThis.filter_tiger === false && item.name.toLowerCase().indexOf('of the tiger') > -1) ||
-                (globalThis.filter_strength === false && item.name.toLowerCase().indexOf('of strength') > -1) ||
-                (globalThis.filter_bear === false && item.name.toLowerCase().indexOf('of the bear') > -1) ||
-                (globalThis.filter_green === false && item.q == "2") ||
-                (globalThis.filter_blue === false && item.q == "3") ||
-                (globalThis.filter_epic === false && item.q == "4") ||
-                (globalThis.filter_timeworn === false && item.tw))) {
-                    if (globalThis.filter_timeworn === true && item.tw) {
-                        // show item
-                    }
-                    else {
-                        continue;
-                    }
+                    (globalThis.filter_strength === false && item.name.toLowerCase().indexOf('of strength') > -1) ||
+                    (globalThis.filter_bear === false && item.name.toLowerCase().indexOf('of the bear') > -1) ||
+                    (globalThis.filter_green === false && item.q == "2") ||
+                    (globalThis.filter_blue === false && item.q == "3") ||
+                    (globalThis.filter_epic === false && item.q == "4") ||
+                    (globalThis.filter_timeworn === false && item.tw))) {
+                if (globalThis.filter_timeworn === true && item.tw) {
+                    // show item
+                }
+                else {
+                    continue;
+                }
             }
 
             let source = (item.source || "").toLowerCase(), phase = item.phase;
@@ -1311,7 +1312,7 @@ SIM.UI = {
 
             if (max == 2 &&
                 ((phase && !view.filter.find('.phases [data-id="' + phase + '"]').hasClass('active')) ||
-                (source && !view.filter.find('.sources [data-id="' + source + '"]').hasClass('active'))))
+                    (source && !view.filter.find('.sources [data-id="' + source + '"]').hasClass('active'))))
                 item.selected = false;
 
             if (phase && !view.filter.find('.phases [data-id="' + phase + '"]').hasClass('active'))
@@ -1331,7 +1332,7 @@ SIM.UI = {
             if (tooltip == 198981) tooltip = 19898;
             if (tooltip == 2207381) tooltip = 220738;
 
-            
+
             if (item.rand) rand = '?rand=' + item.rand;
 
             let resist = '';
@@ -1594,7 +1595,7 @@ SIM.UI = {
         $('.modal .btn-close').click(function() {
             $('.modal').hide();
         });
-        
+
 
     },
 
@@ -1607,40 +1608,40 @@ var searchSVG = '<svg xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 50 50" wi
 function dragElement(elmnt) {
     var pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
     if (elmnt.querySelector('.head')) {
-      // if present, the header is where you move the DIV from:
-      elmnt.querySelector('.head').onmousedown = dragMouseDown;
+        // if present, the header is where you move the DIV from:
+        elmnt.querySelector('.head').onmousedown = dragMouseDown;
     } else {
-      // otherwise, move the DIV from anywhere inside the DIV:
-      elmnt.onmousedown = dragMouseDown;
+        // otherwise, move the DIV from anywhere inside the DIV:
+        elmnt.onmousedown = dragMouseDown;
     }
-  
+
     function dragMouseDown(e) {
-      e = e || window.event;
-      e.preventDefault();
-      // get the mouse cursor position at startup:
-      pos3 = e.clientX;
-      pos4 = e.clientY;
-      document.onmouseup = closeDragElement;
-      // call a function whenever the cursor moves:
-      document.onmousemove = elementDrag;
+        e = e || window.event;
+        e.preventDefault();
+        // get the mouse cursor position at startup:
+        pos3 = e.clientX;
+        pos4 = e.clientY;
+        document.onmouseup = closeDragElement;
+        // call a function whenever the cursor moves:
+        document.onmousemove = elementDrag;
     }
-  
+
     function elementDrag(e) {
-      e = e || window.event;
-      e.preventDefault();
-      // calculate the new cursor position:
-      pos1 = pos3 - e.clientX;
-      pos2 = pos4 - e.clientY;
-      pos3 = e.clientX;
-      pos4 = e.clientY;
-      // set the element's new position:
-      elmnt.style.top = (elmnt.offsetTop - pos2) + "px";
-      elmnt.style.left = (elmnt.offsetLeft - pos1) + "px";
+        e = e || window.event;
+        e.preventDefault();
+        // calculate the new cursor position:
+        pos1 = pos3 - e.clientX;
+        pos2 = pos4 - e.clientY;
+        pos3 = e.clientX;
+        pos4 = e.clientY;
+        // set the element's new position:
+        elmnt.style.top = (elmnt.offsetTop - pos2) + "px";
+        elmnt.style.left = (elmnt.offsetLeft - pos1) + "px";
     }
-  
+
     function closeDragElement() {
-      // stop moving when mouse button is released:
-      document.onmouseup = null;
-      document.onmousemove = null;
+        // stop moving when mouse button is released:
+        document.onmouseup = null;
+        document.onmousemove = null;
     }
-  }
+}

--- a/turtle.html
+++ b/turtle.html
@@ -172,6 +172,7 @@ TO EXPLORE:
         <div id="weight-crit"><span class="stat-name">Crit Chance:</span><span class="stat-dps">12345</span><span class="stat-error">123</span></div>
         <div id="weight-hit"><span class="stat-name">Hit Chance:</span><span class="stat-dps">12345</span><span class="stat-error">123</span></div>
         <div id="weight-haste"><span class="stat-name">Haste:</span><span class="stat-dps">12345</span><span class="stat-error">123</span></div>
+        <div id="weight-exattack"><span class="stat-name">Extra Attack:</span><span class="stat-dps">12345</span><span class="stat-error">123</span></div>
         <div id="weight-arp"><span class="stat-name">Armor Penetration:</span><span class="stat-dps">12345</span><span class="stat-error">123</span></div>
         <div id="weight-mhskill"><span class="stat-name">MH Skill:</span><span class="stat-dps">12345</span><span class="stat-error">123</span></div>
         <div id="weight-ohskill"><span class="stat-name">OH Skill:</span><span class="stat-dps">12345</span><span class="stat-error">123</span></div>


### PR DESCRIPTION
* add extra attacks in stat sim
* regular gear extra attack bonuses start getting counted. until now it's just weps/trinkets

turn off whitespace changes in diff settings somewhere to review

i tried making sure there are no self procs via !damageSoFar

also don't see a reason the trinkets were special cased for extra attacks. they do have some extra ICD logic currently.